### PR TITLE
feat: 에디터 타이틀 이벤트 핸들러 구현

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -1,4 +1,4 @@
-import http from "./http";
+import http from "@/api/http";
 
 const BASE_URL = "https://kdt-api.fe.dev-cos.com/documents";
 const HEADERS = {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -19,6 +19,14 @@ export default async function Editor({ id }) {
   const handleTitleKeyup = () => {
     http.update(id, getBody());
   };
+  const handleTitleKeydown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      content.innerText = "\n" + content.innerText;
+      content.focus();
+    }
+  };
 
   title.addEventListener("keyup", handleTitleKeyup);
+  title.addEventListener("keydown", handleTitleKeydown);
 }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -26,7 +26,14 @@ export default async function Editor({ id }) {
       content.focus();
     }
   };
+  const handleTitlePaste = (e) => {
+    e.preventDefault();
+    const pasteData = e.clipboardData.getData("text/plain");
+    content.innerText = pasteData + "\n" + content.innerText;
+    content.focus();
+  };
 
   title.addEventListener("keyup", handleTitleKeyup);
   title.addEventListener("keydown", handleTitleKeydown);
+  title.addEventListener("paste", handleTitlePaste);
 }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -14,4 +14,11 @@ export default async function Editor({ id }) {
   const content = document.querySelector(".content");
   title.innerText = data.title || "";
   content.innerText = data.content || "";
+
+  const getBody = () => ({ title: title.innerText, content: content.innerText });
+  const handleTitleKeyup = () => {
+    http.update(id, getBody());
+  };
+
+  title.addEventListener("keyup", handleTitleKeyup);
 }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,69 +1,17 @@
-import "./style.css";
-import apiDocs from "../../api/documents";
+import "@/components/Editor/style.css";
+import http from "@/api/documents";
 
 export default async function Editor({ id }) {
   const section = document.querySelector("#section");
-  section.innerHTML = "";
+  section.innerHTML = /* html */ `
+    <div class="document-detail">
+      <h1 class="title" contenteditable="true" data-placeholder="새 페이지"></h1>
+      <div class="content" contenteditable="true"></div>
+    </div>`;
 
-  const div = document.createElement("div");
-  div.className = "document-detail";
-
-  const title = document.createElement("h1");
-  title.id = "title";
-  title.setAttribute("contenteditable", "true");
-  title.setAttribute("placeholder", "새 페이지");
-
-  const contents = document.createElement("textarea");
-  contents.id = "contents";
-
-  div.appendChild(title);
-  div.appendChild(contents);
-  section.appendChild(div);
-
-  /* api */
-  const docData = await apiDocs.get(id);
-
-  // 텍스트 입력 가능, title/contents 내용이 없는 경우 포함
-  if (docData.title === null || docData.title === undefined) {
-    title.innerText = "새 페이지";
-  } else {
-    title.innerText = docData.title;
-  }
-
-  if (docData.content === null || docData.content === undefined) {
-    contents.value = "내용을 입력하세요.";
-  } else {
-    contents.value = docData.content;
-  }
-
-  const getBody = () => {
-    const title = document.querySelector("#title").innerText;
-    const contents = document.querySelector("#contents").value;
-
-    return { title, content: contents };
-  };
-
-  const saveNow = async () => {
-    try {
-      const body = getBody();
-      console.log(">>>>>>>>>>>>>>>", id, body);
-      await apiDocs.update(id, body);
-    } catch (err) {
-      console.error("저장 실패:", err);
-    }
-  };
-
-  title.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      contents.value = "\n" + contents.value;
-      contents.focus();
-      contents.setSelectionRange(0, 0);
-    }
-    setTimeout(saveNow, 0);
-  });
-
-  contents.addEventListener("keydown", () => {
-    setTimeout(saveNow(id), 0);
-  });
+  const data = await http.get(id);
+  const title = document.querySelector(".title");
+  const content = document.querySelector(".content");
+  title.innerText = data.title;
+  content.innerText = data.content;
 }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -12,6 +12,6 @@ export default async function Editor({ id }) {
   const data = await http.get(id);
   const title = document.querySelector(".title");
   const content = document.querySelector(".content");
-  title.innerText = data.title;
-  content.innerText = data.content;
+  title.innerText = data.title || "";
+  content.innerText = data.content || "";
 }

--- a/src/components/Editor/style.css
+++ b/src/components/Editor/style.css
@@ -7,35 +7,31 @@
   justify-content: center;
 }
 
-#title {
+.title {
   width: 100%;
   white-space: break-spaces;
   word-break: break-word;
   color: rgb(50, 48, 44);
   font-size: 2.5em;
+  letter-spacing: -0.02em;
   font-weight: 700;
   cursor: text;
   line-height: 1.2;
   margin-top: 160px;
-  position: sticky;
   outline: none;
+  position: relative;
 }
 
-/* #title[data-empty="true"]::after {
+.title:has(br:only-child)::before {
   content: attr(data-placeholder);
-  position: absolute;
-  inset: 0 auto auto 0;
-  color: #aaa;
+  opacity: 0.15;
   pointer-events: none;
-  user-select: none;
-} */
-
-#title[contenteditable="true"]:empty:before {
-  content: "새 페이지";
-  color: #aaa;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
-#contents {
+.content {
   display: block;
   width: 100%;
   height: 100%;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -11,6 +11,7 @@
   align-items: center;
   height: 100%;
   flex-direction: column;
+  display: flow-root;
 }
 
 .document-detail-placeholder {


### PR DESCRIPTION
## 개요

에디터 타이틀 이벤트 핸들러 구현

## 작업 내용

- [x] 타이틀에서 `keyup` 이벤트가 일어날 경우 바로 저장되도록 구현 (타이틀은 일부러 바로 저장되도록 구현)
- [x] 타이틀에서 `엔터` 입력이 일어날 경우 본문 상단으로 이동하도록 구현
- [x] 타이틀에서 복사 `붙여넣기`를 할 경우 본문 가장 상단에 붙여넣기가 되도록 구현
- [x] 타이틀의 margin-top이 본문이 길어질 경우 마진 상쇄가 일어나 부모 div에 `display: flow-root` 추가

## 기타

타이틀에 관련된 구현은 끝입니다